### PR TITLE
fix reboot handler, and grub modifications

### DIFF
--- a/roles/common/tasks/check-if-restart-required.yml
+++ b/roles/common/tasks/check-if-restart-required.yml
@@ -7,12 +7,15 @@
   ignore_errors: True
   become: true
 
-- shell: ( /bin/sleep 60; shutdown -r now "Ansible updates triggered" ) &
-  async: 30
-  poll: 0
-  ignore_errors: true
-  notify:
-    - waiting for server to come back after reboot
-  when: reboot_required.rc != 0
-  become: true
+- name: Reboot the remote machine if updates occured
+  reboot:
+  when:
+    - reboot_required.rc != 0
+    - ansible_connection != "local"
+
+- name: Reboot the local machine in 60s if updates occured
+  shell: /bin/sleep 60; shutdown -r now "Ansible updates triggered"
+  when:
+    - reboot_required.rc != 0
+    - ansible_connection == "local"
 

--- a/roles/common/tasks/install-packages-fedora.yml
+++ b/roles/common/tasks/install-packages-fedora.yml
@@ -53,7 +53,6 @@
 - name: Install remaining non-important dnf packages
   dnf: 
     name:
-      - grubby
       - dnf-plugin-tracer
     state: latest
   become: true

--- a/roles/common/tasks/modify-grub-fedora.yml
+++ b/roles/common/tasks/modify-grub-fedora.yml
@@ -1,16 +1,20 @@
 ---
 
+# TODO: Not pretty. Move kernel param to it's own variable
+
 # Use Cgroups v1 by default when on Fedora 31
 # https://fedoraproject.org/wiki/Common_F31_bugs#Other_software_issues
-- name: Read the kernel command line parameters
-  shell: cat /proc/cmdline
-  register: kernel_cmd
+- name: Add kernel param if not present to switch to Cgroups v1
+  lineinfile:
+    state: present
+    dest: "{{ docker_host_grub_path }}"
+    backrefs: yes
+    regexp: '^(GRUB_CMDLINE_LINUX=(?!.* systemd.unified_cgroup_hierarchy)\"[^\"]+)(\".*)'
+    line: '\1 systemd.unified_cgroup_hierarchy=0\2'
   become: true
+  register: result
 
-# TODO: Not pretty. Move kernel param to it's own variable
-- name: Add kernel param to switch to Cgroups v1
-  shell: grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
-  when: ansible_facts['distribution_major_version'] == '31' and
-        kernel_cmd.stdout.find('systemd.unified_cgroup_hierarchy') == -1 or
-        kernel_cmd.stdout.find('systemd.unified_cgroup_hierarchy=1') != -1
+- name: Update Grub config
+  command: 'grub2-mkconfig -o {{ docker_host_grub_config_path }}'
+  when: result.changed
   become: true

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -18,3 +18,6 @@ docker_container_service_path: '/etc/systemd/system/{{ docker_container_service_
 docker_container_start_cmd: '/usr/bin/docker run --rm --publish {{ docker_host_port }}:{{ docker_container_port }} --name %n {{ dockerhub_img }}:{{ dockerhub_img_tag }}'
 docker_container_start_pre_cmd: '-/usr/bin/docker rm --force %n' # If you prepend the path with a dash the result will be ignored
 docker_container_stop_cmd: '-/usr/bin/docker container stop %n'
+
+docker_host_grub_path: /etc/default/grub
+docker_host_grub_config_path: /boot/grub2/grub.cfg


### PR DESCRIPTION
### Changes

1.  remove async shell and handler. As of ansible `v2.7` using the `reboot` module is preferred.

2. Grubby is a common util used to simplify the modification of grub configs. For whatever reason (I still need to investigate) `grubby` was returning code `0` even though it failed to add the kernel parameter. The false-success caused docker to fail with `Error response from daemon: OCI runtime create failed: container_linux.go:346`.

Everything has since been fixed.  

